### PR TITLE
New handling for unflaired, new insults, more readability, editing cron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,4 @@ dist
 
 
 #Personal
-*.txt
+*archive

--- a/index.js
+++ b/index.js
@@ -37,10 +37,10 @@ function run() {
 
     console.log('Starting up...')
 
-    cron.schedule('0 0 * * *', () => { //Task executed every day, UTC timezone
-        wallOfShame(db) //Updates Wall of shame instantly
+    cron.schedule('0 */6 * * *', () => { //Task executed every six hours, UTC timezone
+        leaderboard(db) //Updates Wall of shame instantly
         setTimeout(() => { //Updates leaderboard after 10 seconds, avoids RATELIMIT
-            leaderboard(db)
+            wallOfShame(db)
         }, 10000)
     }, {
         timezone: 'UTC'
@@ -213,7 +213,7 @@ async function wallOfShame(db) {
         else
             msg += `- ${item.name}\xa0\xa0\xa0-\xa0\xa0\xa0${item.flair.length - 1} flair changes\n\n`
     })
-    msg += '\n*This post is automatically updated every day at midnight UTC.*'
+    msg += '\n*This post is automatically updated every six hours.*'
     r.getSubmission('utwvvg').edit(msg) //Update post
 }
 
@@ -230,7 +230,7 @@ async function leaderboard(db) {
         i++
         msg += `${i}) ${item.name}\xa0\xa0\xa0-\xa0\xa0\xa0${item.size - 1} flair changes\n\n`
     })
-    msg += '\n*This post is automatically updated every day at midnight UTC.*'
+    msg += '\n*This post is automatically updated every six hours.*'
     await r.getSubmission('uuhlu2').edit(msg) //Update post
 }
 

--- a/maintenance/test.js
+++ b/maintenance/test.js
@@ -31,14 +31,9 @@ const r = new Snoowrap({
 (async() => {
 
     await client.connect()
-    const db = client.db('flairChangeBot')
+    const db = client.db('flairChangeBot').collection('PCM_users')
 
-    let log = await db.collection('PCM_users').findOne({ name: 'Nerd02' })
+    let log = await db.findOne({ name: 'Nerd02' })
     console.log(log)
 
-    if (log.dateAdded[0] < new Date('2022-04-25')) {
-        console.log('Old')
-    } else {
-        console.log('New')
-    }
 })()

--- a/modules/const.js
+++ b/modules/const.js
@@ -1,0 +1,9 @@
+const c = {
+    SUMMON_DELAY: 2, //[minutes] - cooldown for summon with !flairs
+    FLAIR_CHANGE_DELAY: 5, //[minutes] - cooldown for flair change
+    NEIGHBOUR_DICE: 4, //25% - roll for answer to small shifts (neighbouring quadrants)
+    UNFLAIRED_DICE: 10, //10% - roll for answer to unflaired (insult)
+    OPTOUT_DICE: 5, //20% - roll for answer to optout (for users who have already opted out)
+}
+
+module.exports = c

--- a/modules/strings.js
+++ b/modules/strings.js
@@ -46,11 +46,12 @@ function getOptOut() {
     return strings.optOut
 }
 
-//Returns a list of flair changes for the matching 'username'. Includes easter eggs for username == 'flairchange_bot' && 'basedcount_bot'
+//Returns a list of flair changes for the matching 'username'
 function getListFlairs(username, log, delay) {
     let warning = `^(Be aware that some data may be missing, the oldest data I have dates back to 2022-04-25.)\n\n`
     let listFooter = ` ^(Each user can use this command once every ${delay} minutes.)`
 
+    //Easter eggs
     if (username === 'flairchange_bot') {
         return strings.flairsFCBot + '\n\n' + strings.footer + listFooter
     } else if (username === 'basedcount_bot') {
@@ -92,7 +93,13 @@ function getListFlairs(username, log, delay) {
                 msg += `${i + 1}) Started as ${elem} on ${log.dateAdded[i].toUTCString()}.\n\n`
             }
         } else {
-            msg += `${i + 1}) Switched to ${elem} on ${log.dateAdded[i].toUTCString()}.\n\n`
+            if (elem == 'null') {
+                msg += `${i + 1}) Went UNFLAIRED on ${log.dateAdded[i].toUTCString()}.\n\n`
+
+            } else {
+                msg += `${i + 1}) Switched to ${elem} on ${log.dateAdded[i].toUTCString()}.\n\n`
+
+            }
         }
     })
 

--- a/modules/unflaired.js
+++ b/modules/unflaired.js
@@ -3,9 +3,14 @@ const responses = [
     "I don't care. No one does. Get a flair right now or get the hell out of my sub.",
     "Flair the fuck up or leave this sub at once.",
     "The only thing more cringe than changing one's flair is not having one. You are cringe.",
-    "If you don't get a flair right now I'll have AuthLeft make you face the wall.",
+    // "If you don't get a flair right now I'll have AuthLeft make you face the wall.",         //[removed] to please my technocratic overlords
     "If I were you I'd flair the fuck up rather quickly, the mob will be here in no time.",
-    "Despite making up only 13% of the population, unflaired make 100% of the cringe in this sub."
+    "Despite making up only 13% of the population, unflaired make 100% of the cringe in this sub.",
+    "For the crime of being unflaired, I hereby condemn you to being downvoted.",
+    "I see no flair next to your name, why are you still talking?",
+    "Get a flair or get going.",
+    "Cringe and unflaired pilled",
+    "Roses are red,  \n violets are blue;  \n flair changing is cringe  \n and so are you."
 ]
 
 module.exports = responses


### PR DESCRIPTION
Introducing flair `null` for user switching to unflaired. Added handling for such flair in both summon and flairChange.
Removing bannable insult, adding new ones
Introducing new separate file for constants (parameters)
Updating cron expression, now the Leaderboard and the Wall of Shame are updated every 6 hours starting from midnight UTC
Minor edits to .gitignore
Rearranging function positioning, adding whitespaces, overall improving readability